### PR TITLE
Pin setuptools_scm to 5.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=34.4", "wheel", "setuptools_scm>=1.15"]
+requires = ["setuptools>=34.4", "wheel", "setuptools_scm==5.0.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]


### PR DESCRIPTION
As noted in pypa/setuptools_scm#541, the latest version of that tool fails to build in Python 2.7, so the solution seems to be to pin the version to 5.0.2.

For context, I was getting the error mentioned in that issue when trying to install [metabrainz/sir](https://github.com/metabrainz/sir), which relies on this package. 