### PR TITLE
Fix python version constraint for pytest-mypy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ testing =
 	pytest-cov; python_version >= "3"
 	# python_implementation: workaround for jaraco/skeleton#22
 	# python_version: workaround for python/typed_ast#156
-	pytest-mypy; python_implementation != "PyPy" and python_version < "3.10" and python_version > "3"
+	pytest-mypy; python_implementation != "PyPy" and python_version < "3.10" and python_version >= "3"
 	pytest-enabler >= 1.0.1; python_version >= "3.0"
 
 	# local


### PR DESCRIPTION
`<3.10 >3` seems not a valid version constraint. And it breaks [poetry](https://github.com/python-poetry/poetry) version resolving. Related issue: https://github.com/python-poetry/poetry/issues/534

This PR fixes the python version constraint for `pytest-mypy`.