### PR TITLE
Add missing setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
setup.py was missing in 1.6.5 which broke any library that fetches the latest version of backports.functools-lru-cache.